### PR TITLE
Improve PHP security

### DIFF
--- a/create.php
+++ b/create.php
@@ -7,9 +7,9 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
 
     try {
 
-        $student_id = $_POST['student_id'];
-        $student_name = $_POST['student_name'];
-        $student_score = $_POST['student_score'];
+        $student_id = filter_input(INPUT_POST, 'student_id', FILTER_SANITIZE_STRING);
+        $student_name = filter_input(INPUT_POST, 'student_name', FILTER_SANITIZE_STRING);
+        $student_score = filter_input(INPUT_POST, 'student_score', FILTER_VALIDATE_INT);
     
         $sql = "INSERT INTO students ( no , name , score ) VALUES (:student_id, :student_name, :student_score)";
         $stmt = $connect->prepare($sql);
@@ -19,9 +19,11 @@ if ($_SERVER['REQUEST_METHOD'] == 'POST') {
         $stmt->execute();
 
         header('Location: index.php');
+        exit;
 
     } catch (PDOException $e) {
-        echo "<script>alert('บันทึกข้อมูลไม่สำเร็จ: " . $e->getMessage() . "')</script>";
+        error_log('Insert failed: ' . $e->getMessage());
+        echo "<script>alert('บันทึกข้อมูลไม่สำเร็จ')</script>";
     }
 }
 

--- a/database.php
+++ b/database.php
@@ -1,13 +1,15 @@
 <?php
 
 //connect to database use PDO
-$database_name = "students";
-$database_user = "root";
-$database_password = "root";
+$database_name = getenv('DB_NAME') ?: 'students';
+$database_user = getenv('DB_USER') ?: 'root';
+$database_password = getenv('DB_PASSWORD') ?: 'root';
 
 try {
     $connect = new PDO("mysql:host=localhost;dbname=$database_name", $database_user, $database_password);
     $connect->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
 } catch (PDOException $e) {
-    echo "<script>alert('Connection failed: " . $e->getMessage() . "')</script>";
+    error_log('Connection failed: ' . $e->getMessage());
+    die('Database connection error.');
 }
+

--- a/delete.php
+++ b/delete.php
@@ -3,7 +3,7 @@
 require_once 'database.php';
 
 if (isset($_GET['id'])) {
-    $id = $_GET['id'];
+    $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
 
     $sql = "DELETE FROM students WHERE id = :id";
     $stmt = $connect->prepare($sql);
@@ -11,9 +11,11 @@ if (isset($_GET['id'])) {
 
     if ($stmt->execute()) {
         header('Location: index.php');
+        exit;
     } else {
         echo "<script>alert('ลบข้อมูลไม่สำเร็จ')</script>";
     }
 } else {
     header('Location: index.php');
+    exit;
 }

--- a/edit.php
+++ b/edit.php
@@ -3,7 +3,7 @@
 require_once 'database.php';
 
 if (isset($_GET['id'])) {
-    $id = $_GET['id'];
+    $id = filter_input(INPUT_GET, 'id', FILTER_VALIDATE_INT);
 
     $sql = "SELECT * FROM students WHERE id = :id";
     $stmt = $connect->prepare($sql);
@@ -15,9 +15,9 @@ if (isset($_GET['id'])) {
 
         try {
 
-            $student_id = $_POST['student_id'];
-            $student_name = $_POST['student_name'];
-            $student_score = $_POST['student_score'];
+            $student_id = filter_input(INPUT_POST, 'student_id', FILTER_SANITIZE_STRING);
+            $student_name = filter_input(INPUT_POST, 'student_name', FILTER_SANITIZE_STRING);
+            $student_score = filter_input(INPUT_POST, 'student_score', FILTER_VALIDATE_INT);
 
             $sql = "UPDATE students SET no = :student_id, name = :student_name, score = :student_score WHERE id = :id";
             $stmt = $connect->prepare($sql);
@@ -28,14 +28,17 @@ if (isset($_GET['id'])) {
             $stmt->execute();
 
             header('Location: index.php');
+            exit;
         } catch (PDOException $e) {
-            echo "<script>alert('บันทึกข้อมูลไม่สำเร็จ: " . $e->getMessage() . "')</script>";
+            error_log('Update failed: ' . $e->getMessage());
+            echo "<script>alert('บันทึกข้อมูลไม่สำเร็จ')</script>";
         }
     } else {
         $student = $stmt->fetch(PDO::FETCH_ASSOC);
     }
 } else {
     header('Location: index.php');
+    exit;
 }
 
 ?>

--- a/index.php
+++ b/index.php
@@ -3,10 +3,10 @@
 require_once 'database.php';
 
 
-$sql = "SELECT * FROM students";
-$stmt = $connect->prepare($sql);
-$stmt->execute();
-$students = $stmt->fetchAll(PDO::FETCH_ASSOC);
+    $sql = "SELECT * FROM students";
+    $stmt = $connect->prepare($sql);
+    $stmt->execute();
+    $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
 
 
 ?>
@@ -73,15 +73,15 @@ $students = $stmt->fetchAll(PDO::FETCH_ASSOC);
                                 $grade = 'F';
                             }
 
-                            echo "<tr>";
-                            echo "<td>{$student['no']}</td>";
-                            echo "<td>{$student['name']}</td>";
-                            echo "<td>{$student['score']}</td>";
-                            echo "<td>{$grade}</td>";
-                            echo "<td>
-                                <a href='edit.php?id={$student['id']}' class='btn btn-warning'>แก้ไข</a>
-                                <a href='delete.php?id={$student['id']}' class='btn btn-danger'>ลบ</a>
-                            </td>";
+                            echo '<tr>';
+                            echo '<td>' . htmlspecialchars($student['no'], ENT_QUOTES, 'UTF-8') . '</td>';
+                            echo '<td>' . htmlspecialchars($student['name'], ENT_QUOTES, 'UTF-8') . '</td>';
+                            echo '<td>' . htmlspecialchars($student['score'], ENT_QUOTES, 'UTF-8') . '</td>';
+                            echo '<td>' . $grade . '</td>';
+                            echo '<td>' .
+                                "<a href='edit.php?id=" . urlencode($student['id']) . "' class='btn btn-warning'>แก้ไข</a> " .
+                                "<a href='delete.php?id=" . urlencode($student['id']) . "' class='btn btn-danger'>ลบ</a>" .
+                            '</td>';
                             echo "</tr>";
                         }
 


### PR DESCRIPTION
## Summary
- sanitize outputs when listing students
- read DB credentials from environment and hide connection errors
- sanitize and validate user input
- exit after redirects to prevent continuing execution

## Testing
- `php -l index.php` *(fails: `php` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685c27d3f3c883329285f9d02694038c